### PR TITLE
#4 Add Merge PR commit & ReleaseNotes bump patterns

### DIFF
--- a/Fake.Extensions.Release.sln
+++ b/Fake.Extensions.Release.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30907.101
+# Visual Studio Version 17
+VisualStudioVersion = 17.6.33829.357
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{7246FAC5-EF00-4626-96E0-A16702407630}"
 	ProjectSection(SolutionItems) = preProject
@@ -9,6 +9,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		build.cmd = build.cmd
 		build.fsx = build.fsx
 		build.sh = build.sh
+		playground.fsx = playground.fsx
 		README.md = README.md
 		RELEASE_NOTES.md = RELEASE_NOTES.md
 	EndProjectSection
@@ -17,7 +18,7 @@ Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Fake.Extensions.Release", "
 EndProject
 Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Fake.Extensions.Release.Tests", "tests\Fake.Extensions.Release.Tests\Fake.Extensions.Release.Tests.fsproj", "{2A5D96F8-9387-4130-BBFD-01298DE956E0}"
 EndProject
-Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "build", "build\build.fsproj", "{6A11913A-3BF2-462B-862D-F2312668DCB1}"
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "build", "build\build.fsproj", "{6A11913A-3BF2-462B-862D-F2312668DCB1}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/playground.fsx
+++ b/playground.fsx
@@ -1,0 +1,116 @@
+#I "src/Fake.Extensions.Release/bin/Release/netstandard2.0"
+#I "src/Fake.Extensions.Release/bin/Debug/netstandard2.0"
+#r "Fake.Extensions.Release.dll"
+
+#r "nuget: Fake.Core.Target"
+#r "nuget: Fake.Core.ReleaseNotes"
+#r "nuget: Fake.Tools.Git"
+
+
+open Fake.Extensions.Release.ReleaseNotes.Aux
+open Fake.Core
+
+
+// ++++++++++++++++++++
+// CopyPasta from files
+// ++++++++++++++++++++
+
+/// Updates RELEASE_NOTES.md by accessing git commits.
+let update(owner : string, repoName : string, config : TargetParameter)=
+
+    printfn "works1"
+
+    let nOfLastCommitsToCheck =
+        let opt =
+            config.Context.Arguments
+            |> List.tryFind (fun x -> x.StartsWith "n:")
+        if opt.IsSome then opt.Value.Replace("n:","") else "30"
+    printfn "works2"
+
+    let lastReleaseNotes, prevReleaseNotes = 
+        // must change to System.IO because Fake.IO ofc only works in Fake context -_-
+        let all = Fake.IO.File.read "RELEASE_NOTES.md" |> ReleaseNotes.parseAll
+        if all.Length = 0 then
+            ReleaseNotes.ReleaseNotes.initReleaseNotes(), []
+        else 
+            all.Head, all.Tail
+
+    Trace.tracefn "Found latest release notes (%A, from %A)" lastReleaseNotes.SemVer.Original lastReleaseNotes.Date
+
+    let lastCommitHash = if lastReleaseNotes.SemVer.BuildMetaData <> "" then Some <| lastReleaseNotes.SemVer.BuildMetaData else None
+
+    match lastCommitHash with
+    | Some hash -> Trace.tracef "Found last commit '%s'.%A" hash System.Environment.NewLine
+    | None -> Trace.tracef "No last commit found. Add the last (if existing) '%s' commits." nOfLastCommitsToCheck
+
+    //https://git-scm.com/book/en/v2/Git-Basics-Viewing-the-Commit-History#pretty_format
+    let (_,gitCommits,_) = Fake.Tools.Git.CommandHelper.runGitCommand "" ("log -" + nOfLastCommitsToCheck + " --pretty=format:\"%H;%h;%s\"")
+
+    /// returns all commits done after the one notes in "SemVer.BuildMetaData"
+    let newGitCommits =
+        if lastCommitHash.IsSome then
+            let tryFindLastCommitIndex = gitCommits |> List.tryFindIndex (fun y -> y.Contains lastCommitHash.Value)
+            if tryFindLastCommitIndex.IsNone then
+                failwithf
+                    "Could not find last version git hash: %s in the last %s commits.
+                    You can increase the number of searched commits by passing a argument
+                    as such \"dotnet fake build -t release n:50\""
+                    lastReleaseNotes.SemVer.BuildMetaData nOfLastCommitsToCheck
+            gitCommits
+            |> List.take (tryFindLastCommitIndex.Value)
+        else
+            gitCommits
+
+    newGitCommits
+
+// ++++++++++++++++++++
+
+
+let target : Target = {
+    Name                = ""
+    Dependencies        = []
+    SoftDependencies    = []
+    Description         = None
+    Function            = (fun _ -> ())
+}
+
+let config = {
+    TargetInfo  = target
+    Context     = TargetContext.Create "" [] [] (new System.Threading.CancellationToken())
+}
+
+let project = "Fake.Extensions.Release"
+
+let gitOwner = "Freymaurer"
+
+let projectRepo = $"https://github.com/{gitOwner}/{project}"
+
+update(gitOwner, projectRepo, config)
+
+
+open System.Text.RegularExpressions
+
+let filterOutUnimportantCommits commitNoteArr =
+    printfn "%A" commitNoteArr
+    // matches: "update(or)bump release_(or)-(or) notes(followed by anything)"
+    //let releaseNotesPattern = Regex @"^(update|bump).+release[_\s-]?notes(.*)?$"
+    let releaseNotesPattern = Regex @"^(update|bump).+release[_\s-]?notes"
+    let mergePattern = Regex @"^merge.+(branch|pull request)"
+    commitNoteArr
+    |> Array.filter (fun (x: string []) ->
+        let line = x.[2].ToLower()
+        match line with
+        | y when (releaseNotesPattern.Match y).Success || (mergePattern.Match y).Success -> false
+        | _ -> true
+    )
+
+filterOutUnimportantCommits [|
+    [|"lal"; "schmüh"; "gadi"|]
+    [|"lal"; "schmüh"; "PULL REQUEST!"|]
+    [|"lal"; "schmüh"; "MERGE PULL REQUEST!"|]
+    [|"lal"; "schmüh"; "MERGE BRANCH     asd"|]
+    [|"lal"; "schmüh"; "Update dein Gesicht!"|]
+    [|"lal"; "schmüh"; "Update deine release notes"|]
+    [|"lal"; "schmüh"; "Bump mommy's release notes"|]
+    [|"lal"; "schmüh"; "Bump mommy's release_notes.md"|]
+|]

--- a/src/Fake.Extensions.Release/Fake.Extensions.Release.fsproj
+++ b/src/Fake.Extensions.Release/Fake.Extensions.Release.fsproj
@@ -24,8 +24,8 @@
 
   <PropertyGroup>
     <Authors>Kevin Frey</Authors>
-    <Description>A libary for extended release notes functions using FAKE.</Description>
-    <Summary>A libary for extended release notes functions using FAKE.</Summary>
+    <Description>A library for extended release notes functions using FAKE.</Description>
+    <Summary>A library for extended release notes functions using FAKE.</Summary>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <!--<PackageProjectUrl>https://fslab.org/docs-template/</PackageProjectUrl>-->
     <!--<PackageIconUrl>https://fslab.org/docs-template/img/logo.png</PackageIconUrl>-->

--- a/src/Fake.Extensions.Release/ReleaseNotes.fs
+++ b/src/Fake.Extensions.Release/ReleaseNotes.fs
@@ -2,6 +2,7 @@
 
 open Fake.Core
 open System
+open System.Text.RegularExpressions
 
 [<Obsolete("Changed naming to 'ReleaseNotes'")>]
 module Release =
@@ -242,12 +243,14 @@ module ReleaseNotes =
             let newSemVer = updateSemVer semVer latestCommitHash lastReleaseNotes.SemVer
             /// This will be used to directly create the release notes
             let formattedCommitNoteList =
+                let releaseNotesPattern = Regex @"^(update|bump).+release[_\s-]?notes(\.md)?$"
                 commitNoteArr
                 // filter out unimportant commits
                 |> Array.filter (fun (x: string []) ->
-                    let (lineContains: string -> bool) = x.[2].ToLower().Contains
-                    match lineContains with
-                    | x when x "update release_notes.md" || x "update release notes" -> false
+                    let line = x.[2].ToLower()
+                    match line with
+                    | y when (releaseNotesPattern.Match y).Success -> false
+                    | y when y.Contains "merge pull request" -> false
                     | _ -> true
                 )
                 |> Array.map (fun x ->

--- a/src/Fake.Extensions.Release/ReleaseNotes.fs
+++ b/src/Fake.Extensions.Release/ReleaseNotes.fs
@@ -243,7 +243,8 @@ module ReleaseNotes =
             let newSemVer = updateSemVer semVer latestCommitHash lastReleaseNotes.SemVer
             /// This will be used to directly create the release notes
             let formattedCommitNoteList =
-                let releaseNotesPattern = Regex @"^(update|bump).+release[_\s-]?notes(\.md)?$"
+                // matches: "update(or)bump release_(or)-(or) notes(followed by anything)"
+                let releaseNotesPattern = Regex @"^(update|bump).+release[_\s-]?notes(.*)?$"
                 commitNoteArr
                 // filter out unimportant commits
                 |> Array.filter (fun (x: string []) ->

--- a/tests/Fake.Extensions.Release.Tests/ReleaseNotes.Tests.fs
+++ b/tests/Fake.Extensions.Release.Tests/ReleaseNotes.Tests.fs
@@ -52,3 +52,30 @@ let tests_ReleaseNotes_Extensions =
             let newNotes = ReleaseNotes.ReleaseNotes.initReleaseNotes()
             Expect.equal (newNotes.SemVer.ToSemVer()) "0.0.0" "newNotes.SemVer.ToSemVer()"
     ]
+
+[<Tests>]
+let tests_filterOutUnimportantCommits =
+    testList "filterOutUnimportantCommits" [
+        let testCommits = [|
+            [|"2b59f8423783574a47e3e6dc7a4bc6108e74aea8"; "2b59f84"; "Add description to Regex pattern";|]
+            [|"968c7d53e6eb38cf67038a26f8e4403a84b11b3d"; "968c7d5"; "Add patterns to match PR merge commits & RN bumps";|]
+            [|"626265c22ee0862a52ebf814d131dfd1137e22d3"; "626265c"; "Update README.md";|]
+            [|"626265c22ee0862a52ebf814d131dfd1137e22d3"; "626265c"; "Update release notes";|]
+            [|"626265c22ee0862a52ebf814d131dfd1137e22d3"; "626265c"; "Update release_notes";|]
+            [|"626265c22ee0862a52ebf814d131dfd1137e22d3"; "626265c"; "Update release notes.md";|]
+            [|"626265c22ee0862a52ebf814d131dfd1137e22d3"; "626265c"; "Bump release notes.md";|]
+            [|"b4f4a6fc22c5e918a3d2f45e67fd9e20a12a6cfb"; "b4f4a6f"; "Add nuget package commit link removal.";|]
+            [|"210575d5da41cd315d6bf0a38cc8b08b282c6cf7"; "210575d"; "Merge branch 'main' of https://github.com/Freymaurer/Fake.Extensions.Release";|]
+            [|"210575d5da41cd315d6bf0a38cc8b08b282c6cf7"; "210575d"; "Merge Pull Request #31 of ... to ...";|]
+            [|"458c87f0d1fb41ae999b156a713dfdfb2d9496fd"; "458c87f"; "Update RELEASE_NOTES.md"|]
+        |]
+        let testCommitsExpected = [|
+            [|"2b59f8423783574a47e3e6dc7a4bc6108e74aea8"; "2b59f84"; "Add description to Regex pattern";|]
+            [|"968c7d53e6eb38cf67038a26f8e4403a84b11b3d"; "968c7d5"; "Add patterns to match PR merge commits & RN bumps";|]
+            [|"626265c22ee0862a52ebf814d131dfd1137e22d3"; "626265c"; "Update README.md";|]
+            [|"b4f4a6fc22c5e918a3d2f45e67fd9e20a12a6cfb"; "b4f4a6f"; "Add nuget package commit link removal.";|]
+        |]
+        testCase "Test filterOutUnimportantCommits" <| fun _ ->
+            let result = filterOutUnimportantCommits testCommits
+            Expect.sequenceEqual result testCommitsExpected ""
+    ]


### PR DESCRIPTION
This PR
- adds functionality to exclude commits that are about PR merges and updates of the RELEASE_NOTES.md file
- closes #4

I wasn't able to provide unit tests since the functionality to test is so heavily encapsulated into a 120 LoC function with heavy I/O side-effects that this would have resulted in a much too big overhaul of the Test project. So I skipped it.