### PR TITLE
Add match case for new prerelease command

### DIFF
--- a/tests/Fake.Extensions.Release.Tests/ReleaseNotes.Tests.fs
+++ b/tests/Fake.Extensions.Release.Tests/ReleaseNotes.Tests.fs
@@ -40,9 +40,15 @@ let tests_SemVerArgs =
         testCase "Test SemVerArg :patch" <| fun _ ->
             let result = ["semver:patch"] |> matchSemVerArg 
             Expect.equal result Patch ""
-        testCase "Test SemVerArg :pre-alpha.02" <| fun _ ->
-            let result = ["semver:pre-alpha.02"] |> matchSemVerArg 
-            Expect.equal result (Pre "alpha.02") ""
+    ]
+
+[<Tests>]
+let tests_SemVerPreArgs =
+    testList "SemVerPreArgs" [
+        testCase "Test SemVerPreArg pre:alpha.02" <| fun _ ->
+            let result = ["pre:alpha.02"] |> matchPreArg
+            Expect.isSome result "Is not some"
+            Expect.equal result.Value (Pre "alpha.02") "Has incorrect SemVerPrerelease tag"
     ]
 
 [<Tests>]


### PR DESCRIPTION
This PR
- adds a new command which is "pre:<name>" and works via cumulating normal SemVer increases and Prerelease tag (e.g. Input: `build releasenotes semver:major pre:alpha.0` –> SemVer: `X+1.Y.Z.-alpha.0`)
  - adds unit tests for this